### PR TITLE
Vtk prompt fixes

### DIFF
--- a/src/vtk_prompt/client.py
+++ b/src/vtk_prompt/client.py
@@ -379,9 +379,18 @@ class VTKPromptClient:
                 yaml_messages = self._format_custom_prompt(
                     custom_prompt, message, context_snippets
                 )
-                if self.verbose:
+                if not yaml_messages:
+                    logger.warning(
+                        "custom_prompt provided but defines no 'messages'; "
+                        "falling back to built-in prompt assembly"
+                    )
+                elif self.verbose:
                     logger.debug("Using custom YAML prompt from file")
             else:
+                yaml_messages = []
+
+            # Fall back to component assembly when no usable custom messages exist.
+            if not yaml_messages:
                 from .prompts import PYTHON_VERSION, VTK_VERSION
 
                 prompt_data = assemble_vtk_prompt(

--- a/src/vtk_prompt/client.py
+++ b/src/vtk_prompt/client.py
@@ -28,6 +28,7 @@ import openai
 from . import get_logger
 from .prompts import assemble_vtk_prompt
 from .provider_utils import DEFAULT_MODEL
+from .utils.helpers import ensure_vtk_importable
 
 logger = get_logger(__name__)
 
@@ -502,12 +503,7 @@ class VTKPromptClient:
             generated_explanation = expl_matches[0]
             generated_code = code_matches[0]
 
-            if "import vtk" not in generated_code:
-                generated_code = "import vtk\n" + generated_code
-            else:
-                pos = generated_code.find("import vtk")
-                if pos != -1:
-                    generated_code = generated_code[pos:]
+            generated_code = ensure_vtk_importable(generated_code)
 
             is_valid, error_msg = self.validate_code_syntax(generated_code)
             if is_valid:

--- a/src/vtk_prompt/controllers/configuration.py
+++ b/src/vtk_prompt/controllers/configuration.py
@@ -45,11 +45,13 @@ def save_config(app: Any) -> str:
     retries = int(getattr(app.state, "retry_attempts", 1))
     mcp_url = getattr(app.state, "mcp_url", "").strip()
     top_k = int(getattr(app.state, "top_k", 5))
+    base_url = getattr(app.state, "local_base_url", "").strip() if not use_cloud else ""
 
     content = {
         "name": "Custom VTK Prompt config file",
         "description": f"Exported from UI - {'Cloud' if use_cloud else 'Local'} configuration",
         "model": provider_model,
+        "base_url": base_url,
         "mcp_url": mcp_url,
         "top_k": top_k,
         "retries": retries,

--- a/src/vtk_prompt/prompts/yaml_prompt_loader.py
+++ b/src/vtk_prompt/prompts/yaml_prompt_loader.py
@@ -21,6 +21,13 @@ PROMPTS_DIR = Path(__file__).parent
 class YAMLPromptLoader:
     """Class for loading and processing YAML prompts."""
 
+    # Variable keys that carry large blocks of trusted content (e.g. code
+    # examples retrieved from vtk-mcp). These bypass the scalar-oriented safety
+    # checks in _validate_variable_value, which exist to guard small templating
+    # scalars and would otherwise reject legitimate example code (such as an
+    # ``if __name__ == "__main__":`` guard) or any snippet over the length cap.
+    _RAW_CONTENT_KEYS = frozenset({"context_snippets"})
+
     def __init__(self) -> None:
         """Initialize the loader."""
         self.prompts_dir = PROMPTS_DIR
@@ -44,6 +51,12 @@ class YAMLPromptLoader:
             raise ValueError(f"Variable '{key}' cannot be None")
 
         str_value = str(value)
+
+        # Trusted large-content variables (retrieved code context) skip the
+        # scalar guards below: example code legitimately contains dunders and
+        # can exceed the length cap meant for small templating scalars.
+        if key in self._RAW_CONTENT_KEYS:
+            return str_value
 
         # Check for potentially dangerous content
         dangerous_patterns = [

--- a/src/vtk_prompt/rendering/code_executor.py
+++ b/src/vtk_prompt/rendering/code_executor.py
@@ -23,14 +23,24 @@ def execute_vtk_code(
         # Ensure vtk is importable without clobbering module-specific imports
         code_segment = ensure_vtk_importable(code_string)
 
-        # Create execution globals with renderer available
+        # Create execution globals with renderer available.
+        # Notes:
+        # - __name__ is set to "__main__" so generated scripts guarded by
+        #   `if __name__ == "__main__":` actually run. Without it, a bare
+        #   __name__ resolves via builtins to "builtins", the guard is False,
+        #   and the script body (e.g. a main()) never executes -> blank view.
+        # - render_window is injected alongside renderer for code that uses it.
+        # - A single namespace (globals only) is used so top-level defs and the
+        #   guard share one scope and functions can see the injected names.
         exec_globals = {
             "vtk": vtk,
             "renderer": renderer,
+            "render_window": render_window,
+            "__name__": "__main__",
         }
 
         # Execute the code
-        exec(code_segment, exec_globals, {})
+        exec(code_segment, exec_globals)
 
         # Reset camera and render
         try:

--- a/src/vtk_prompt/rendering/code_executor.py
+++ b/src/vtk_prompt/rendering/code_executor.py
@@ -3,6 +3,7 @@
 import vtk
 
 from .. import get_logger
+from ..utils.helpers import ensure_vtk_importable
 
 logger = get_logger(__name__)
 
@@ -19,15 +20,8 @@ def execute_vtk_code(
         # Clear previous actors
         renderer.RemoveAllViewProps()
 
-        # Clean the code
-        pos = code_string.find("import vtk")
-        if pos != -1:
-            code_string = code_string[pos:]
-
-        # Ensure vtk is imported
-        code_segment = code_string
-        if "import vtk" not in code_segment:
-            code_segment = "import vtk\n" + code_segment
+        # Ensure vtk is importable without clobbering module-specific imports
+        code_segment = ensure_vtk_importable(code_string)
 
         # Create execution globals with renderer available
         exec_globals = {

--- a/src/vtk_prompt/state/config_state.py
+++ b/src/vtk_prompt/state/config_state.py
@@ -11,9 +11,19 @@ from ..provider_utils import DEFAULT_MODEL
 
 
 def get_api_key(app: Any) -> str | None:
-    """Get API key from state (requires manual input in UI)."""
+    """Get API key from state.
+
+    Cloud providers need a real key. Local models hit an OpenAI-compatible
+    endpoint (Ollama, LM Studio, ...) that ignores auth, but the OpenAI client
+    still refuses to construct with an empty key, so in local mode we fall back
+    to a placeholder. A real key typed into the field overrides it.
+    """
     api_token = getattr(app.state, "api_token", "")
-    return api_token.strip() if api_token and api_token.strip() else None
+    if api_token and api_token.strip():
+        return api_token.strip()
+    if not app.state.use_cloud_models:
+        return "sk-no-key-required"
+    return None
 
 
 def get_base_url(app: Any) -> str | None:

--- a/src/vtk_prompt/state/initializer.py
+++ b/src/vtk_prompt/state/initializer.py
@@ -5,6 +5,7 @@ This module provides functions for initializing application state variables
 and setting up the VTK Prompt UI application state.
 """
 
+import os
 from typing import Any
 
 from .. import get_logger
@@ -71,7 +72,11 @@ def initialize_state(app: Any) -> None:
     # Load component defaults and sync UI state
     _load_component_defaults(app)
 
-    app.state.api_token = ""
+    # Seed the API token from the environment (e.g. OPENAI_API_KEY from a .env)
+    # so the token field is populated without manual entry. Without this the
+    # "Generate Code" button stays hidden (it is gated on api_token), which is a
+    # dead end when the key is supplied via environment rather than typed.
+    app.state.api_token = os.environ.get("OPENAI_API_KEY", "")
 
     # Build UI
     app._build_ui()

--- a/src/vtk_prompt/ui/layout/content.py
+++ b/src/vtk_prompt/ui/layout/content.py
@@ -80,6 +80,7 @@ def build_content(layout: Any, app: Any) -> None:
                                     rows=4,
                                     variant="outlined",
                                     placeholder=("e.g., Create a red sphere with lighting"),
+                                    persistent_placeholder=True,
                                     hide_details=True,
                                     no_resize=True,
                                 )

--- a/src/vtk_prompt/ui/layout/content.py
+++ b/src/vtk_prompt/ui/layout/content.py
@@ -116,7 +116,7 @@ def build_content(layout: Any, app: Any) -> None:
                                 loading=("trame__busy", False),
                                 click=app.ctrl.generate_code,
                                 classes="my-2",
-                                v_show="api_token.trim()",
+                                v_show="!use_cloud_models || api_token.trim()",
                             )
                             vuetify.VBtn(
                                 "Set API Key",

--- a/src/vtk_prompt/ui/layout/settings_dialog.py
+++ b/src/vtk_prompt/ui/layout/settings_dialog.py
@@ -2,7 +2,7 @@
 Settings Dialog Layout Module.
 
 This module provides the advanced settings dialog layout for the VTK Prompt UI.
-The dialog contains model configuration, RAG settings, and file controls.
+The dialog contains model configuration, vtk-mcp settings, and file controls.
 """
 
 from typing import Any
@@ -180,15 +180,21 @@ def build_settings_dialog(layout: Any, app: Any) -> None:
 
                     # Advanced Settings Tab
                     with vuetify.VTabsWindowItem(value="advanced"):
-                        # RAG Settings Card
+                        # vtk-mcp Settings Card
                         with vuetify.VCard(classes="mt-2"):
-                            vuetify.VCardTitle("⚙️  RAG settings", classes="pb-0")
+                            vuetify.VCardTitle("🔌 vtk-mcp", classes="pb-0")
                             with vuetify.VCardText():
-                                vuetify.VCheckbox(
-                                    v_model=("use_rag", False),
-                                    label="RAG",
-                                    prepend_icon="mdi-bookshelf",
+                                vuetify.VTextField(
+                                    label="vtk-mcp Server URL",
+                                    v_model=("mcp_url", ""),
+                                    placeholder="http://localhost:8000",
+                                    clearable=True,
                                     density="compact",
+                                    variant="outlined",
+                                    prepend_icon="mdi-bookshelf",
+                                    hint="Enables context retrieval and VTK API "
+                                    "validation; leave blank for baseline generation",
+                                    persistent_hint=True,
                                 )
                                 vuetify.VTextField(
                                     label="Top K",
@@ -197,7 +203,7 @@ def build_settings_dialog(layout: Any, app: Any) -> None:
                                     min=1,
                                     max=15,
                                     density="compact",
-                                    disabled=("!use_rag",),
+                                    disabled=("!mcp_url",),
                                     variant="outlined",
                                     prepend_icon="mdi-chart-scatter-plot",
                                 )

--- a/src/vtk_prompt/ui/layout/settings_dialog.py
+++ b/src/vtk_prompt/ui/layout/settings_dialog.py
@@ -234,7 +234,7 @@ def build_settings_dialog(layout: Any, app: Any) -> None:
                                 )
                                 vuetify.VTextField(
                                     label="Retry Attempts",
-                                    v_model=("retry_attempts", 1),
+                                    v_model=("retry_attempts", 3),
                                     type="number",
                                     min=1,
                                     max=5,

--- a/src/vtk_prompt/utils/env_config.py
+++ b/src/vtk_prompt/utils/env_config.py
@@ -1,0 +1,71 @@
+"""Startup discovery of a default config file and .env files for the UI.
+
+Lets ``vtk-prompt-ui`` run with no arguments and still pick up a saved
+configuration and environment variables (e.g. API tokens), instead of
+requiring ``--prompt-file`` and an inline ``OPENAI_API_KEY=...`` prefix.
+"""
+
+import os
+from pathlib import Path
+
+CONFIG_ENV_VAR = "VTK_PROMPT_CONFIG"
+APP_DIR_NAME = "vtk-prompt"
+
+
+def _config_home() -> Path:
+    """Return the per-user config directory (XDG-aware)."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / APP_DIR_NAME
+
+
+def discover_config_file() -> str | None:
+    """Return the first existing default config path, or None.
+
+    Search order:
+      1. ``$VTK_PROMPT_CONFIG`` (explicit path)
+      2. ``./vtk-prompt.yml`` / ``./vtk-prompt.yaml`` (current directory)
+      3. ``~/.config/vtk-prompt/config.yml`` / ``config.yaml``
+    """
+    explicit = os.environ.get(CONFIG_ENV_VAR)
+    if explicit and Path(explicit).is_file():
+        return explicit
+
+    candidates = [
+        Path.cwd() / "vtk-prompt.yml",
+        Path.cwd() / "vtk-prompt.yaml",
+        _config_home() / "config.yml",
+        _config_home() / "config.yaml",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def load_dotenv_files() -> list[str]:
+    """Load simple ``KEY=VALUE`` pairs from .env files into ``os.environ``.
+
+    Existing environment variables are never overwritten. Returns the list of
+    files actually loaded. Search order:
+      1. ``~/.config/vtk-prompt/.env``
+      2. ``./.env`` (current directory)
+    """
+    loaded: list[str] = []
+    for path in (_config_home() / ".env", Path.cwd() / ".env"):
+        if not path.is_file():
+            continue
+        try:
+            for raw in path.read_text().splitlines():
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, val = line.partition("=")
+                key = key.strip()
+                val = val.strip().strip('"').strip("'")
+                if key:
+                    os.environ.setdefault(key, val)
+            loaded.append(str(path))
+        except OSError:
+            continue
+    return loaded

--- a/src/vtk_prompt/utils/helpers.py
+++ b/src/vtk_prompt/utils/helpers.py
@@ -4,6 +4,8 @@ Helpers Module.
 This module provides general helper functions and constants for the VTK Prompt UI application.
 """
 
+import re
+
 # Constants
 EXPLAIN_RENDERER = (
     "# renderer is a vtkRenderer injected by this webapp"
@@ -14,3 +16,32 @@ EXPLAIN_RENDERER = (
 EXPLANATION_PATTERN = r"<explanation>(.*?)</explanation>"
 CODE_PATTERN = r"<code>(.*?)</code>"
 EXTRA_INSTRUCTIONS_TAG = "</extra_instructions>"
+
+
+def ensure_vtk_importable(code: str) -> str:
+    """Ensure generated VTK code can run without clobbering module-specific imports.
+
+    Strips a surrounding markdown fence if present, then prepends a top-level
+    ``import vtk`` only when the snippet has neither a real ``import vtk`` line nor
+    any ``vtkmodules`` import.
+
+    A naive ``"import vtk" in code`` substring test is intentionally avoided: it
+    matches inside ``import vtkSphereSource``, which previously caused valid
+    ``from vtkmodules.X import vtkY`` code to be truncated to ``import vtkY`` and
+    fail at runtime with ``No module named 'vtkY'``.
+    """
+    code = code.strip()
+
+    # Strip a single surrounding markdown code fence if the model emitted one
+    if code.startswith("```"):
+        code = re.sub(r"^```[A-Za-z0-9_-]*\n?", "", code)
+        code = re.sub(r"\n?```$", "", code).strip()
+
+    has_vtk_import = bool(
+        re.search(r"^\s*import\s+vtk(\s+as\s+\w+)?\s*$", code, re.MULTILINE)
+        or re.search(r"\bvtkmodules\b", code)
+    )
+    if not has_vtk_import:
+        code = "import vtk\n" + code
+
+    return code

--- a/src/vtk_prompt/utils/prompt_loader.py
+++ b/src/vtk_prompt/utils/prompt_loader.py
@@ -104,6 +104,14 @@ def _process_rag_and_generation_settings(app: Any) -> None:
             app.state.retry_attempts = int(_retries)
         else:
             logger.warning("Invalid retries in prompt file: %r; keeping existing", _retries)
+    if "mcp_url" in app.custom_prompt_data:
+        _mcp = app.custom_prompt_data.get("mcp_url")
+        if isinstance(_mcp, str):
+            app.state.mcp_url = _mcp.strip()
+    if "base_url" in app.custom_prompt_data:
+        _base = app.custom_prompt_data.get("base_url")
+        if isinstance(_base, str) and _base.strip():
+            app.state.local_base_url = _base.strip()
 
 
 def _process_model_parameters(app: Any) -> None:

--- a/src/vtk_prompt/utils/prompt_loader.py
+++ b/src/vtk_prompt/utils/prompt_loader.py
@@ -49,6 +49,18 @@ def apply_custom_prompt_data(app: Any, data: dict[str, Any]) -> None:
         _process_rag_and_generation_settings(app)
         _process_model_parameters(app)
 
+        # A file is only treated as a *prompt* if it defines messages.
+        # A config file (model/base_url/mcp_url/top_k/... but no messages)
+        # supplies settings only; keeping it as custom_prompt_data would make
+        # the client send an empty message list to the LLM. Settings above are
+        # already applied to app.state, so discard the non-prompt payload.
+        if "messages" not in data:
+            logger.info(
+                "Loaded file has no 'messages'; treating as config only, "
+                "built-in prompts will be used."
+            )
+            app.custom_prompt_data = None
+
 
 def _process_model_configuration(app: Any) -> None:
     """Process model configuration from custom prompt data."""

--- a/src/vtk_prompt/vtk_prompt_ui.py
+++ b/src/vtk_prompt/vtk_prompt_ui.py
@@ -240,6 +240,12 @@ class VTKPromptApp(TrameApp):
 
 def main() -> None:
     """Start the trame app."""
+    from .utils.env_config import discover_config_file, load_dotenv_files
+
+    # Load .env files (e.g. API tokens) before anything reads the environment
+    for env_file in load_dotenv_files():
+        print(f"Loaded environment from {env_file}")
+
     print("VTK Prompt UI - Enter your API token in the application settings.")
     print("Supported providers: OpenAI, Anthropic, Google Gemini, NVIDIA NIM")
     print("For local Ollama, use custom base URL and model configuration.")
@@ -252,6 +258,12 @@ def main() -> None:
         if arg == "--prompt-file" and i + 1 < len(sys.argv):
             custom_prompt_file = sys.argv[i + 1]
             break
+
+    # Fall back to an auto-discovered default config when not given explicitly
+    if custom_prompt_file is None:
+        custom_prompt_file = discover_config_file()
+        if custom_prompt_file:
+            print(f"Using config: {custom_prompt_file}")
 
     # Create and start the app
     app = VTKPromptApp(custom_prompt_file=custom_prompt_file)

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -1,0 +1,46 @@
+"""Tests for custom config round-trip (model/base_url/mcp_url restore)."""
+
+import types
+
+from vtk_prompt.utils import prompt_loader
+
+
+def _fake_app(data):
+    app = types.SimpleNamespace()
+    app.custom_prompt_file = None
+    app.custom_prompt_data = data
+    app.state = types.SimpleNamespace()
+    return app
+
+
+def test_loader_restores_local_ollama_and_mcp():
+    cfg = {
+        "model": "local/qwen2.5-coder-32b-ctx16",
+        "base_url": "http://192.168.50.157:11434/v1",
+        "mcp_url": "http://localhost:8000",
+        "top_k": 5,
+        "retries": 3,
+        "modelParameters": {"temperature": 0.1, "max_tokens": 4000},
+    }
+    app = _fake_app(cfg)
+    prompt_loader._process_model_configuration(app)
+    prompt_loader._process_rag_and_generation_settings(app)
+    prompt_loader._process_model_parameters(app)
+
+    assert app.state.use_cloud_models is False
+    assert app.state.tab_index == 1
+    assert app.state.local_model == "qwen2.5-coder-32b-ctx16"
+    assert app.state.local_base_url == "http://192.168.50.157:11434/v1"
+    assert app.state.mcp_url == "http://localhost:8000"
+    assert app.state.top_k == 5
+    assert app.state.retry_attempts == 3
+
+
+def test_loader_sets_mcp_url_for_cloud_model():
+    cfg = {"model": "anthropic/claude-sonnet-4-6", "mcp_url": "http://localhost:8000"}
+    app = _fake_app(cfg)
+    prompt_loader._process_model_configuration(app)
+    prompt_loader._process_rag_and_generation_settings(app)
+    assert app.state.use_cloud_models is True
+    assert app.state.provider == "anthropic"
+    assert app.state.mcp_url == "http://localhost:8000"

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,70 @@
+"""Tests for default config and .env auto-discovery."""
+
+import os
+
+import pytest
+
+from vtk_prompt.utils import env_config
+
+
+@pytest.fixture(autouse=True)
+def _restore_environ():
+    """load_dotenv_files mutates os.environ directly; snapshot and restore it."""
+    saved = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(saved)
+
+
+def test_explicit_env_var_wins(tmp_path, monkeypatch):
+    cfg = tmp_path / "my.yml"
+    cfg.write_text("model: anthropic/x\n")
+    monkeypatch.setenv(env_config.CONFIG_ENV_VAR, str(cfg))
+    assert env_config.discover_config_file() == str(cfg)
+
+
+def test_cwd_config_discovered(tmp_path, monkeypatch):
+    monkeypatch.delenv(env_config.CONFIG_ENV_VAR, raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "vtk-prompt.yml").write_text("model: anthropic/x\n")
+    assert env_config.discover_config_file() == str(tmp_path / "vtk-prompt.yml")
+
+
+def test_xdg_config_home_discovered(tmp_path, monkeypatch):
+    monkeypatch.delenv(env_config.CONFIG_ENV_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)  # no cwd config present
+    xdg = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    appdir = xdg / "vtk-prompt"
+    appdir.mkdir(parents=True)
+    (appdir / "config.yml").write_text("model: anthropic/x\n")
+    assert env_config.discover_config_file() == str(appdir / "config.yml")
+
+
+def test_none_when_absent(tmp_path, monkeypatch):
+    monkeypatch.delenv(env_config.CONFIG_ENV_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    assert env_config.discover_config_file() is None
+
+
+def test_dotenv_loaded(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    (tmp_path / ".env").write_text('OPENAI_API_KEY="ollama"\n# c\nFOO=bar\n')
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("FOO", raising=False)
+    loaded = env_config.load_dotenv_files()
+    assert str(tmp_path / ".env") in loaded
+    assert os.environ["OPENAI_API_KEY"] == "ollama"
+    assert os.environ["FOO"] == "bar"
+
+
+def test_dotenv_does_not_override_existing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=fromfile\n")
+    monkeypatch.setenv("OPENAI_API_KEY", "preexisting")
+    env_config.load_dotenv_files()
+    assert os.environ["OPENAI_API_KEY"] == "preexisting"

--- a/tests/test_executor_guarded_main.py
+++ b/tests/test_executor_guarded_main.py
@@ -1,0 +1,51 @@
+"""Regression test: webapp executor must run guarded-main generated scripts.
+
+LLMs frequently emit standalone scripts wrapped in:
+
+    def main(): ...
+    if __name__ == "__main__":
+        main()
+
+The webapp executes these with an injected ``renderer``. If __name__ is not set
+to "__main__" in the exec namespace, a bare __name__ resolves via builtins to
+"builtins", the guard is False, main() never runs, and nothing reaches the
+renderer (blank view, no error). This test guards against that regression.
+"""
+
+import pytest
+
+vtk = pytest.importorskip("vtk")
+
+from vtk_prompt.rendering.code_executor import execute_vtk_code  # noqa: E402
+
+GUARDED_SPHERE = """
+from vtkmodules.vtkFiltersSources import vtkSphereSource
+from vtkmodules.vtkRenderingCore import vtkActor, vtkPolyDataMapper
+
+
+def main():
+    sphere = vtkSphereSource()
+    mapper = vtkPolyDataMapper()
+    mapper.SetInputConnection(sphere.GetOutputPort())
+    actor = vtkActor()
+    actor.SetMapper(mapper)
+    renderer.AddActor(actor)
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+def test_guarded_main_script_adds_actor_to_renderer():
+    try:
+        renderer = vtk.vtkRenderer()
+        render_window = vtk.vtkRenderWindow()
+        render_window.SetOffScreenRendering(1)
+        render_window.AddRenderer(renderer)
+    except Exception:  # pragma: no cover - no VTK rendering backend available
+        pytest.skip("VTK render window unavailable in this environment")
+
+    ok, err = execute_vtk_code(GUARDED_SPHERE, renderer, render_window)
+    assert ok, err
+    assert renderer.GetActors().GetNumberOfItems() == 1

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,45 @@
+"""Tests for vtk_prompt.utils.helpers."""
+
+from vtk_prompt.utils.helpers import ensure_vtk_importable
+
+
+def test_leading_import_vtk_unchanged():
+    code = "import vtk\nsrc = vtk.vtkSphereSource()\n"
+    assert ensure_vtk_importable(code).splitlines()[0] == "import vtk"
+
+
+def test_vtkmodules_import_not_truncated():
+    # Regression: a bare "import vtk" substring search used to truncate this to
+    # "import vtkSphereSource", failing at runtime with No module named.
+    code = "from vtkmodules.vtkFiltersSources import vtkSphereSource\nsrc = vtkSphereSource()\n"
+    out = ensure_vtk_importable(code)
+    assert out.splitlines()[0] == "from vtkmodules.vtkFiltersSources import vtkSphereSource"
+    # never decapitated into a standalone module import
+    assert "import vtkSphereSource" not in out.splitlines()
+
+
+def test_parametric_torus_import_not_truncated():
+    code = (
+        "from vtkmodules.vtkCommonComputationalGeometry import vtkParametricTorus\n"
+        "t = vtkParametricTorus()\n"
+    )
+    out = ensure_vtk_importable(code)
+    assert out.startswith("from vtkmodules.vtkCommonComputationalGeometry import vtkParametricTorus")
+
+
+def test_prepends_import_when_absent():
+    code = "s = vtk.vtkConeSource()\n"
+    assert ensure_vtk_importable(code).splitlines()[0] == "import vtk"
+
+
+def test_strips_markdown_fence():
+    code = "```python\nfrom vtkmodules.vtkFiltersSources import vtkSphereSource\n```\n"
+    out = ensure_vtk_importable(code)
+    assert out.splitlines()[0] == "from vtkmodules.vtkFiltersSources import vtkSphereSource"
+    assert "```" not in out
+
+
+def test_import_vtk_as_alias_recognized():
+    code = "import vtk as v\nv.vtkSphereSource()\n"
+    out = ensure_vtk_importable(code)
+    assert out.count("import vtk") == 1  # not prepended a second time

--- a/tests/test_prompt_loader_config.py
+++ b/tests/test_prompt_loader_config.py
@@ -1,0 +1,79 @@
+"""Regression tests: a config file (no 'messages') must not be used as a prompt.
+
+A file loaded via custom_prompt_file is only a *prompt* when it defines messages.
+A settings-only config (model/base_url/mcp_url/top_k/...) must apply its settings
+but leave custom_prompt_data as None so the client uses built-in prompt assembly.
+Otherwise the client sends an empty messages list and the LLM returns HTTP 400.
+"""
+
+import types
+
+import yaml
+
+from vtk_prompt.utils.prompt_loader import load_custom_prompt_file
+
+
+def _mk_app(path: str) -> types.SimpleNamespace:
+    app = types.SimpleNamespace()
+    app.custom_prompt_file = str(path)
+    app.custom_prompt_data = None
+    app.state = types.SimpleNamespace(
+        error_message="",
+        top_k=0,
+        retry_attempts=0,
+        mcp_url="",
+        local_base_url="",
+        use_cloud_models=True,
+        tab_index=0,
+        provider="",
+        model="",
+        local_model="",
+        temperature_supported=True,
+        temperature=0.0,
+        max_tokens=0,
+    )
+    return app
+
+
+def test_config_only_file_is_not_used_as_prompt(tmp_path):
+    p = tmp_path / "config.yml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "model": "local/qwen2.5-coder",
+                "base_url": "http://x:11434/v1",
+                "mcp_url": "http://localhost:8000",
+                "top_k": 5,
+                "retries": 3,
+            }
+        )
+    )
+    app = _mk_app(p)
+    load_custom_prompt_file(app)
+
+    # Not treated as a prompt ...
+    assert app.custom_prompt_data is None
+    # ... but the settings were still applied.
+    assert app.state.use_cloud_models is False
+    assert app.state.local_model == "qwen2.5-coder"
+    assert app.state.local_base_url == "http://x:11434/v1"
+    assert app.state.mcp_url == "http://localhost:8000"
+    assert app.state.top_k == 5
+    assert app.state.retry_attempts == 3
+
+
+def test_prompt_file_with_messages_is_kept(tmp_path):
+    p = tmp_path / "prompt.yml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "model": "local/qwen2.5-coder",
+                "messages": [{"role": "system", "content": "hi"}],
+            }
+        )
+    )
+    app = _mk_app(p)
+    load_custom_prompt_file(app)
+
+    assert app.custom_prompt_data is not None
+    assert "messages" in app.custom_prompt_data

--- a/tests/test_yaml_loader_validation.py
+++ b/tests/test_yaml_loader_validation.py
@@ -1,0 +1,25 @@
+"""Regression tests for YAMLPromptLoader variable validation.
+
+Retrieved code context (context_snippets) must bypass the scalar-oriented
+safety guards: example code legitimately contains dunders like ``__main__`` and
+can exceed the 10000-char cap. Small scalar variables stay validated.
+"""
+
+import pytest
+
+from vtk_prompt.prompts.yaml_prompt_loader import YAMLPromptLoader
+
+
+def test_context_snippets_allows_code_with_dunders_and_over_length():
+    loader = YAMLPromptLoader()
+    code = 'if __name__ == "__main__":\n    main()\n' + "x = 1\n" * 5000  # >10000 chars
+    out = loader.substitute_yaml_variables(
+        "{{context_snippets}}", {"context_snippets": code}
+    )
+    assert out == code  # passed through untouched, no ValueError
+
+
+def test_scalar_variable_still_rejects_dunder_content():
+    loader = YAMLPromptLoader()
+    with pytest.raises(ValueError):
+        loader.substitute_yaml_variables("{{VTK_VERSION}}", {"VTK_VERSION": "__import__"})


### PR DESCRIPTION
## Summary

A batch of independent bug and UX fixes for the vtk-prompt UI and its
vtk-mcp / config plumbing. These accumulated while building the editor
work and don't depend on it, so they're split out here to land on their
own. The editor feature builds on this branch and follows in a separate
PR.

## Config and startup

- Zero-arg startup now auto-discovers configuration (`VTK_PROMPT_CONFIG`,
  `./vtk-prompt.yml`, `~/.config/vtk-prompt/config.yml`) and loads `.env`,
  so `vtk-prompt-ui` comes up configured without explicit flags.
- Config round-trip is complete: the loader reads `mcp_url` and
  `base_url`, and `save_config` writes `base_url` back out (previously
  dropped on save).
- The `api_token` is seeded from `OPENAI_API_KEY`, so the Generate button
  appears when the key comes from `.env` or the environment rather than
  only from manual entry in the dialog.

## vtk-mcp integration and prompt assembly

- Replaced the dead RAG checkbox with a vtk-mcp URL field and gated Top K
  on `mcp_url`, matching the move to delegate VTK knowledge to vtk-mcp.
- Fixed an empty-messages 400: config files with no `messages` key are
  settings-only, not prompts, so the client now falls back to built-in
  prompt assembly instead of sending an empty request.
- Fixed retrieved `context_snippets` being rejected as "dangerous": the
  scalar guards (dunder / length checks) now exempt trusted
  retrieved-code variables.

## Code generation and rendering

- Fixed the renderer round-trip: generated code is exec'd with
  `__name__ == "__main__"` in a single namespace so scripts guarded by
  `if __name__ == "__main__":` actually run, and `render_window` is
  injected alongside `renderer`. Without this the guarded scripts no-op'd
  to a blank view.
- Fixed import normalization that truncated
  `from vtkmodules.X import vtkY` down to `import vtkY`.

## UI

- Added `persistent_placeholder` on the prompt textarea to stop the label
  and placeholder text overlapping.

## Notes

Base is `master`. The editor / completion feature is stacked on top of
this branch in a follow-up PR; merging this first lets that PR retarget
to `master` cleanly.