### PR TITLE
Use dict literals in editor language defs (flake8 C408)

### DIFF
--- a/src/vtk_prompt/ui/langs/__init__.py
+++ b/src/vtk_prompt/ui/langs/__init__.py
@@ -5,7 +5,7 @@ from . import python
 
 def build_textmate() -> dict:
     """Build the textmate bundle passed to code.Editor's ``textmate`` prop."""
-    config: dict = dict(languages=[], grammars={}, configs={})
+    config: dict = {"languages": [], "grammars": {}, "configs": {}}
     python.register_lang(config)
     return config
 

--- a/src/vtk_prompt/ui/langs/python/__init__.py
+++ b/src/vtk_prompt/ui/langs/python/__init__.py
@@ -15,13 +15,13 @@ GRAMMAR_TYPE = "json"
 def register_lang(config: dict) -> None:
     """Append the Python language, grammar, and config into a textmate bundle."""
     config["languages"].append(
-        dict(
-            id="python",
-            extensions=[".py", ".pyw", ".pyi"],
-            aliases=["Python", "py"],
-            filenames=[],
-            firstLine=r"^#!\s*/?.*\bpython[0-9.-]*\b",
-        )
+        {
+            "id": "python",
+            "extensions": [".py", ".pyw", ".pyi"],
+            "aliases": ["Python", "py"],
+            "filenames": [],
+            "firstLine": r"^#!\s*/?.*\bpython[0-9.-]*\b",
+        }
     )
     config["configs"]["python"] = CONFIGURATION
     config["grammars"]["source.python"] = {


### PR DESCRIPTION
flake8-comprehensions flags the dict(...) calls in the textmate bundle builder and the Python language entry; rewrite them as literals. No behavior change. unstick #43