### PR TITLE
Feat/mcp tooling

### DIFF
--- a/src/vtk_prompt/client.py
+++ b/src/vtk_prompt/client.py
@@ -296,6 +296,7 @@ class VTKPromptClient:
         custom_prompt: dict | None = None,
         ui_mode: bool = False,
         execution_error: str | None = None,
+        log_tool_calls: bool = False,
     ) -> tuple[str, str, Any] | tuple[str, str, Any, list[str]] | str:
         """Generate VTK code using vtk-mcp tools when available.
 
@@ -468,7 +469,15 @@ class VTKPromptClient:
                         except Exception:
                             args = {}
                         result = mcp_client.call_tool(tc.function.name, args)  # type: ignore
-                        logger.debug("Tool %s -> %s...", tc.function.name, result[:80])
+                        if log_tool_calls:
+                            logger.info(
+                                "vtk-mcp: %s(%s) -> %s",
+                                tc.function.name,
+                                tc.function.arguments,
+                                result[:120],
+                            )
+                        else:
+                            logger.debug("Tool %s -> %s...", tc.function.name, result[:80])
                         self.conversation.append(
                             {"role": "tool", "tool_call_id": tc.id, "content": result}
                         )
@@ -480,6 +489,11 @@ class VTKPromptClient:
 
             if content is None:
                 # Tool loop exhausted without a text response
+                if log_tool_calls:
+                    logger.info(
+                        "vtk-mcp: tool loop hit the %d-round cap without a final response",
+                        MAX_TOOL_ROUNDS,
+                    )
                 if attempt == retry_attempts - 1:
                     return ("No response generated", "", getattr(response, "usage", None) or {})
                 continue

--- a/src/vtk_prompt/client.py
+++ b/src/vtk_prompt/client.py
@@ -331,6 +331,7 @@ class VTKPromptClient:
         ui_mode: bool = False,
         execution_error: str | None = None,
         log_tool_calls: bool = False,
+        agentic_retrieval: bool = False,
     ) -> tuple[str, str, Any] | tuple[str, str, Any, list[str]] | str:
         """Generate VTK code using vtk-mcp tools when available.
 
@@ -394,7 +395,8 @@ class VTKPromptClient:
         else:
             # Normal path: build context and prompt
             context_snippets = None
-            if mcp_client:
+            # Agentic mode: skip pre-injected context so the model must use tools.
+            if mcp_client and not agentic_retrieval:
                 mcp_context = mcp_client.get_enriched_context(message, top_k=top_k)
                 if mcp_context:
                     context_snippets = mcp_context

--- a/src/vtk_prompt/client.py
+++ b/src/vtk_prompt/client.py
@@ -33,6 +33,40 @@ from .utils.helpers import ensure_vtk_importable
 logger = get_logger(__name__)
 
 
+def _parse_text_tool_calls(content: str | None, tool_names: set[str]) -> list[dict] | None:
+    """Extract tool calls a backend emitted as text instead of structured tool_calls.
+
+    Some local OpenAI-compatible backends (e.g. Ollama with a quantized model) return
+    a tool call as plain content rather than populating ``tool_calls``. Handle both a
+    ``<tool_call>{...}</tool_call>`` block and a bare JSON object with ``name`` and
+    ``arguments``. Only objects whose name matches a known tool are treated as calls,
+    so normal tagged answers are never misread. Returns a list of {name, arguments}.
+    """
+    if not content:
+        return None
+    candidates = re.findall(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", content, re.DOTALL)
+    if not candidates:
+        stripped = content.strip()
+        if stripped.startswith("{") and stripped.endswith("}"):
+            candidates = [stripped]
+    calls: list[dict] = []
+    for raw in candidates:
+        try:
+            obj = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        name = obj.get("name")
+        args = obj.get("arguments", {})
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except (ValueError, TypeError):
+                args = {}
+        if name in tool_names and isinstance(args, dict):
+            calls.append({"name": name, "arguments": args})
+    return calls or None
+
+
 @dataclass
 class VTKPromptClient:
     """OpenAI client for VTK code generation."""
@@ -418,6 +452,7 @@ class VTKPromptClient:
 
         # Fetch vtk-mcp tools for LLM tool calling
         tools = mcp_client.list_tools() if mcp_client else []
+        tool_names = {(t.get("function") or {}).get("name") for t in tools}
 
         # Retry loop for AST validation
         for attempt in range(retry_attempts):
@@ -482,6 +517,43 @@ class VTKPromptClient:
                             {"role": "tool", "tool_call_id": tc.id, "content": result}
                         )
                     continue  # let LLM decide what to do next
+
+                # Fallback: the backend returned a tool call as plain text rather than
+                # in tool_calls (common with quantized local models). Run it anyway.
+                text_calls = _parse_text_tool_calls(choice.message.content, tool_names)
+                if tools and text_calls:
+                    self.conversation.append(
+                        {
+                            "role": "assistant",
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": f"call_{i}",
+                                    "type": "function",
+                                    "function": {
+                                        "name": c["name"],
+                                        "arguments": json.dumps(c["arguments"]),
+                                    },
+                                }
+                                for i, c in enumerate(text_calls)
+                            ],
+                        }
+                    )
+                    for i, c in enumerate(text_calls):
+                        result = mcp_client.call_tool(c["name"], c["arguments"])  # type: ignore
+                        if log_tool_calls:
+                            logger.info(
+                                "vtk-mcp (text): %s(%s) -> %s",
+                                c["name"],
+                                json.dumps(c["arguments"]),
+                                result[:120],
+                            )
+                        else:
+                            logger.debug("Tool %s (text) -> %s...", c["name"], result[:80])
+                        self.conversation.append(
+                            {"role": "tool", "tool_call_id": f"call_{i}", "content": result}
+                        )
+                    continue
 
                 # LLM generated a response (not a tool call)
                 content = choice.message.content or "No content in response"

--- a/src/vtk_prompt/client.py
+++ b/src/vtk_prompt/client.py
@@ -454,7 +454,11 @@ class VTKPromptClient:
 
         # Fetch vtk-mcp tools for LLM tool calling
         tools = mcp_client.list_tools() if mcp_client else []
-        tool_names = {(t.get("function") or {}).get("name") for t in tools}
+        tool_names: set[str] = {
+            str(name)
+            for t in tools
+            if (name := (t.get("function") or {}).get("name")) is not None
+        }
 
         # Retry loop for AST validation
         for attempt in range(retry_attempts):
@@ -524,23 +528,19 @@ class VTKPromptClient:
                 # in tool_calls (common with quantized local models). Run it anyway.
                 text_calls = _parse_text_tool_calls(choice.message.content, tool_names)
                 if tools and text_calls:
-                    self.conversation.append(
+                    text_msg: dict = {"role": "assistant", "content": ""}
+                    text_msg["tool_calls"] = [
                         {
-                            "role": "assistant",
-                            "content": "",
-                            "tool_calls": [
-                                {
-                                    "id": f"call_{i}",
-                                    "type": "function",
-                                    "function": {
-                                        "name": c["name"],
-                                        "arguments": json.dumps(c["arguments"]),
-                                    },
-                                }
-                                for i, c in enumerate(text_calls)
-                            ],
+                            "id": f"call_{i}",
+                            "type": "function",
+                            "function": {
+                                "name": c["name"],
+                                "arguments": json.dumps(c["arguments"]),
+                            },
                         }
-                    )
+                        for i, c in enumerate(text_calls)
+                    ]
+                    self.conversation.append(text_msg)
                     for i, c in enumerate(text_calls):
                         result = mcp_client.call_tool(c["name"], c["arguments"])  # type: ignore
                         if log_tool_calls:

--- a/src/vtk_prompt/controllers/configuration.py
+++ b/src/vtk_prompt/controllers/configuration.py
@@ -47,6 +47,7 @@ def save_config(app: Any) -> str:
     data_root = getattr(app.state, "data_root", "").strip()
     top_k = int(getattr(app.state, "top_k", 5))
     log_tool_calls = bool(getattr(app.state, "log_tool_calls", False))
+    agentic_retrieval = bool(getattr(app.state, "agentic_retrieval", False))
     base_url = getattr(app.state, "local_base_url", "").strip() if not use_cloud else ""
 
     content = {
@@ -58,6 +59,7 @@ def save_config(app: Any) -> str:
         "data_root": data_root,
         "top_k": top_k,
         "log_tool_calls": log_tool_calls,
+        "agentic_retrieval": agentic_retrieval,
         "retries": retries,
         "modelParameters": {
             "temperature": temperature,

--- a/src/vtk_prompt/controllers/configuration.py
+++ b/src/vtk_prompt/controllers/configuration.py
@@ -46,6 +46,7 @@ def save_config(app: Any) -> str:
     mcp_url = getattr(app.state, "mcp_url", "").strip()
     data_root = getattr(app.state, "data_root", "").strip()
     top_k = int(getattr(app.state, "top_k", 5))
+    log_tool_calls = bool(getattr(app.state, "log_tool_calls", False))
     base_url = getattr(app.state, "local_base_url", "").strip() if not use_cloud else ""
 
     content = {
@@ -56,6 +57,7 @@ def save_config(app: Any) -> str:
         "mcp_url": mcp_url,
         "data_root": data_root,
         "top_k": top_k,
+        "log_tool_calls": log_tool_calls,
         "retries": retries,
         "modelParameters": {
             "temperature": temperature,

--- a/src/vtk_prompt/controllers/generation.py
+++ b/src/vtk_prompt/controllers/generation.py
@@ -103,6 +103,7 @@ async def generate_and_execute_code(app: Any) -> None:
                 temperature=float(app.state.temperature),
                 top_k=int(app.state.top_k),
                 retry_attempts=int(app.state.retry_attempts),
+                log_tool_calls=bool(app.state.log_tool_calls),
                 provider=app.state.provider,
                 custom_prompt=app.custom_prompt_data,
                 ui_mode=True,  # This tells the client to use UI-specific components
@@ -176,6 +177,7 @@ async def generate_and_execute_code(app: Any) -> None:
                 temperature=float(app.state.temperature),
                 top_k=int(app.state.top_k),
                 retry_attempts=1,
+                log_tool_calls=bool(app.state.log_tool_calls),
                 provider=app.state.provider,
                 custom_prompt=app.custom_prompt_data,
                 ui_mode=True,

--- a/src/vtk_prompt/controllers/generation.py
+++ b/src/vtk_prompt/controllers/generation.py
@@ -104,6 +104,7 @@ async def generate_and_execute_code(app: Any) -> None:
                 top_k=int(app.state.top_k),
                 retry_attempts=int(app.state.retry_attempts),
                 log_tool_calls=bool(app.state.log_tool_calls),
+                agentic_retrieval=bool(app.state.agentic_retrieval),
                 provider=app.state.provider,
                 custom_prompt=app.custom_prompt_data,
                 ui_mode=True,  # This tells the client to use UI-specific components
@@ -178,6 +179,7 @@ async def generate_and_execute_code(app: Any) -> None:
                 top_k=int(app.state.top_k),
                 retry_attempts=1,
                 log_tool_calls=bool(app.state.log_tool_calls),
+                agentic_retrieval=bool(app.state.agentic_retrieval),
                 provider=app.state.provider,
                 custom_prompt=app.custom_prompt_data,
                 ui_mode=True,

--- a/src/vtk_prompt/state/initializer.py
+++ b/src/vtk_prompt/state/initializer.py
@@ -51,6 +51,7 @@ def initialize_state(app: Any) -> None:
     app.state.code_history_pos = -1
     app.state.is_loading = False
     app.state.mcp_url = ""
+    app.state.log_tool_calls = False  # log vtk-mcp tool calls to the console
     app.state.error_message = ""
     app.state.input_tokens = 0
     app.state.output_tokens = 0

--- a/src/vtk_prompt/state/initializer.py
+++ b/src/vtk_prompt/state/initializer.py
@@ -52,6 +52,7 @@ def initialize_state(app: Any) -> None:
     app.state.is_loading = False
     app.state.mcp_url = ""
     app.state.log_tool_calls = False  # log vtk-mcp tool calls to the console
+    app.state.agentic_retrieval = False  # skip pre-injected context; use tools
     app.state.error_message = ""
     app.state.input_tokens = 0
     app.state.output_tokens = 0

--- a/src/vtk_prompt/ui/layout/settings_dialog.py
+++ b/src/vtk_prompt/ui/layout/settings_dialog.py
@@ -190,6 +190,15 @@ def _advanced_tab() -> None:
                 hint="Context snippets retrieved per request",
                 persistent_hint=True,
             )
+            vuetify.VCheckbox(
+                label="Log tool calls to the server console",
+                v_model=("log_tool_calls", False),
+                density="compact",
+                color="primary",
+                disabled=("!mcp_url",),
+                hide_details=True,
+                classes="mt-2",
+            )
 
             vuetify.VDivider(classes="my-5")
             _section("Generation")

--- a/src/vtk_prompt/ui/layout/settings_dialog.py
+++ b/src/vtk_prompt/ui/layout/settings_dialog.py
@@ -199,6 +199,14 @@ def _advanced_tab() -> None:
                 hide_details=True,
                 classes="mt-2",
             )
+            vuetify.VCheckbox(
+                label="Agentic retrieval (use tools instead of pre-injected context)",
+                v_model=("agentic_retrieval", False),
+                density="compact",
+                color="primary",
+                disabled=("!mcp_url",),
+                hide_details=True,
+            )
 
             vuetify.VDivider(classes="my-5")
             _section("Generation")

--- a/src/vtk_prompt/utils/prompt_loader.py
+++ b/src/vtk_prompt/utils/prompt_loader.py
@@ -120,6 +120,10 @@ def _process_rag_and_generation_settings(app: Any) -> None:
         _mcp = app.custom_prompt_data.get("mcp_url")
         if isinstance(_mcp, str):
             app.state.mcp_url = _mcp.strip()
+    if "log_tool_calls" in app.custom_prompt_data:
+        _ltc = app.custom_prompt_data.get("log_tool_calls")
+        if isinstance(_ltc, bool):
+            app.state.log_tool_calls = _ltc
     if "base_url" in app.custom_prompt_data:
         _base = app.custom_prompt_data.get("base_url")
         if isinstance(_base, str) and _base.strip():

--- a/src/vtk_prompt/utils/prompt_loader.py
+++ b/src/vtk_prompt/utils/prompt_loader.py
@@ -124,6 +124,10 @@ def _process_rag_and_generation_settings(app: Any) -> None:
         _ltc = app.custom_prompt_data.get("log_tool_calls")
         if isinstance(_ltc, bool):
             app.state.log_tool_calls = _ltc
+    if "agentic_retrieval" in app.custom_prompt_data:
+        _ag = app.custom_prompt_data.get("agentic_retrieval")
+        if isinstance(_ag, bool):
+            app.state.agentic_retrieval = _ag
     if "base_url" in app.custom_prompt_data:
         _base = app.custom_prompt_data.get("base_url")
         if isinstance(_base, str) and _base.strip():


### PR DESCRIPTION
Stacked on #47, which is stacked on #46. The diff here is only the four commits on top.

**Tool calls from local models were silently discarded.** Against Ollama, vtk-mcp appeared
to do nothing: the server was reachable, tools were sent, and the model was deciding to call
them, but nothing ran. Quantized local models often emit the call as plain JSON in the
message content instead of populating `tool_calls`, so the response comes back with
`finish_reason: "stop"` and the loop treated the JSON as the final answer. We now detect a
tool call that arrived as text (bare JSON, or a `<tool_call>` block) whose name matches a
known tool, execute it, and feed the result back like a native call. Anyone running against
a local backend is affected by this.

**Logging.** A "Log tool calls to the server console" setting (off by default). Each call
logs its name, arguments, and a short result as it happens. Previously there was no way to
tell whether the model was using tools at all. Persists in config.

**Agentic retrieval toggle.** Optionally skip the pre-injected RAG context, which runs to
roughly 4.5k tokens and is a large share of a 16k local context window. Note it does not by
itself make a confident quantized model call tools under `tool_choice="auto"`. Off by
default.

**Known gap.** Tool use is still opportunistic: I used qwen2.5-coder-32b-ctx16 and asked about the streamtracer API, the model
answered from memory and hallucinated `SetMaximumErrorTolerance` (really `SetMaximumError`),
which a `vtk_get_class_info` call would have caught. The fix is deterministic
post-validation, calling the vtk-mcp validators on generated code ourselves. Follow-up.