### PR TITLE
feat/embed mcp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  release:
+    types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
@@ -173,3 +175,49 @@ jobs:
         run: |
           uv run vtk-prompt --help
           uv run vtk-mcp --vtk-version 9.6.1 --help
+
+  docker-deploy:
+    name: Build and Push vtk-prompt-with-mcp Image
+    runs-on: ubuntu-latest
+    needs: [format, lint, type, coverage]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'release'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout vtk-prompt
+        uses: actions/checkout@v4
+        with:
+          path: vtk-prompt
+
+      - name: Checkout vtk-mcp
+        uses: actions/checkout@v4
+        with:
+          repository: Kitware/vtk-mcp
+          path: vtk-mcp
+
+      - name: Install Podman
+        run: |
+          sudo apt update
+          sudo apt install -y podman
+
+      - name: Log in to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+      - name: Get short SHA
+        id: slug
+        run: echo "SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push vtk-prompt-with-mcp image
+        run: |
+          GITHUB_REPOSITORY="$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')"
+          podman build -f vtk-prompt/scripts/vtk-prompt-with-mcp.Dockerfile \
+                       --ignorefile vtk-prompt/scripts/vtk-prompt-with-mcp.dockerignore \
+                       -t "ghcr.io/${GITHUB_REPOSITORY}/vtk-prompt-with-mcp:latest" \
+                       -t "ghcr.io/${GITHUB_REPOSITORY}/vtk-prompt-with-mcp:${{ github.sha }}" \
+                       -t "ghcr.io/${GITHUB_REPOSITORY}/vtk-prompt-with-mcp:${{ steps.slug.outputs.SHORT_SHA }}" \
+                       .
+          podman push "ghcr.io/${GITHUB_REPOSITORY}/vtk-prompt-with-mcp:latest"
+          podman push "ghcr.io/${GITHUB_REPOSITORY}/vtk-prompt-with-mcp:${{ github.sha }}"
+          podman push "ghcr.io/${GITHUB_REPOSITORY}/vtk-prompt-with-mcp:${{ steps.slug.outputs.SHORT_SHA }}"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ vtk-prompt "Create a textured cone with 32 resolution" \
   --verbose \
   -t $API_KEY
 
+# Or with an embedded vtk-mcp (no separate server needed)
+vtk-prompt "Create a textured cone with 32 resolution" --embed-mcp -t $API_KEY
+
 # Using different providers
 vtk-prompt "Create a blue cube" --provider openai --model gpt-4.1 -t $OPENAI_API_KEY
 vtk-prompt "Create a cylinder" --provider nim --model meta/llama-3.3-70b-instruct -t $NIM_KEY
@@ -123,6 +126,20 @@ vtk-prompt "Create a cylinder" --provider nim --model meta/llama-3.3-70b-instruc
 
 Context-enhanced generation is powered by [vtk-mcp](https://github.com/Kitware/vtk-mcp), a local
 MCP server that exposes VTK knowledge tools to the LLM.
+
+**Option A: Embedded (no separate server to manage)**
+
+```bash
+pip install "vtk-prompt[embedded-mcp]"
+vtk-prompt "Create a vtkSphereSource with texture mapping" --embed-mcp -t $API_KEY
+```
+
+`--embed-mcp` launches a local vtk-mcp server as a subprocess for the duration
+of the command and tears it down on exit — no docker compose, no manually
+started server, no `--mcp-url` to manage. It is mutually exclusive with
+`--mcp-url`.
+
+**Option B: External server**
 
 1. **Start vtk-mcp** (see its README for setup):
 
@@ -136,9 +153,10 @@ docker compose up   # or: uvicorn vtk_mcp.transport.http:app --port 8000
 vtk-prompt "Create a vtkSphereSource with texture mapping" --mcp-url http://localhost:8000 -t $API_KEY
 ```
 
-When `--mcp-url` is set the LLM has access to all vtk-mcp tools during generation
-(class lookup, method signatures, import validation, semantic search) and the generated code
-is validated against the VTK API with `validate_vtk_code` before being returned.
+Either way, the LLM has access to all vtk-mcp tools during generation (class
+lookup, method signatures, import validation, semantic search) and the
+generated code is validated against the VTK API with `validate_vtk_code`
+before being returned.
 
 ### Python API
 
@@ -256,6 +274,7 @@ Options:
   --base-url TEXT                 Base URL for API (auto-detected or custom)
   -v, --verbose                   Show generated source code
   --mcp-url TEXT                  vtk-mcp server URL (enables context retrieval and code validation)
+  --embed-mcp                     Launch a local vtk-mcp server automatically (requires vtk-prompt[embedded-mcp])
   --top-k INTEGER                 Number of examples to retrieve from vtk-mcp
   --retry-attempts INTEGER        Number of times to retry if validation fails
   --conversation TEXT             Path to conversation file for chat history

--- a/README.md
+++ b/README.md
@@ -130,7 +130,10 @@ MCP server that exposes VTK knowledge tools to the LLM.
 **Option A: Embedded (no separate server to manage)**
 
 ```bash
-pip install "vtk-prompt[embedded-mcp]"
+# vtk-mcp isn't on PyPI yet, so install it (and its sibling libraries) from source
+pip install "git+https://github.com/vicentebolea/vtk-knowledge" \
+            "git+https://github.com/vicentebolea/vtk-validate" \
+            "git+https://github.com/Kitware/vtk-mcp"
 vtk-prompt "Create a vtkSphereSource with texture mapping" --embed-mcp -t $API_KEY
 ```
 
@@ -274,7 +277,7 @@ Options:
   --base-url TEXT                 Base URL for API (auto-detected or custom)
   -v, --verbose                   Show generated source code
   --mcp-url TEXT                  vtk-mcp server URL (enables context retrieval and code validation)
-  --embed-mcp                     Launch a local vtk-mcp server automatically (requires vtk-prompt[embedded-mcp])
+  --embed-mcp                     Launch a local vtk-mcp server automatically (requires vtk-mcp to be installed)
   --top-k INTEGER                 Number of examples to retrieve from vtk-mcp
   --retry-attempts INTEGER        Number of times to retry if validation fails
   --conversation TEXT             Path to conversation file for chat history

--- a/README.md
+++ b/README.md
@@ -140,7 +140,11 @@ vtk-prompt "Create a vtkSphereSource with texture mapping" --embed-mcp -t $API_K
 `--embed-mcp` launches a local vtk-mcp server as a subprocess for the duration
 of the command and tears it down on exit — no docker compose, no manually
 started server, no `--mcp-url` to manage. It is mutually exclusive with
-`--mcp-url`.
+`--mcp-url`. The web UI supports it too:
+
+```bash
+vtk-prompt-ui --embed-mcp
+```
 
 **Option B: External server**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,12 @@ type-minimal = [
     "importlib_resources>=5.0.0",
 ]
 
+# Embedded vtk-mcp support (see --embed-mcp). Not yet on PyPI; install from
+# source, e.g. pip install "git+https://github.com/Kitware/vtk-mcp".
+embedded-mcp = [
+    "vtk-mcp>=1.0.0",
+]
+
 # All optional dependencies
 all = [
     "vtk-prompt[dev,test]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,12 +77,6 @@ type-minimal = [
     "importlib_resources>=5.0.0",
 ]
 
-# Embedded vtk-mcp support (see --embed-mcp). Not yet on PyPI; install from
-# source, e.g. pip install "git+https://github.com/Kitware/vtk-mcp".
-embedded-mcp = [
-    "vtk-mcp>=1.0.0",
-]
-
 # All optional dependencies
 all = [
     "vtk-prompt[dev,test]",

--- a/scripts/vtk-prompt-with-mcp-entrypoint.sh
+++ b/scripts/vtk-prompt-with-mcp-entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Starts the local Qdrant process (available on :6333 for anyone who wants to
+# index or inspect it), waits for it to accept connections, then runs
+# vtk-prompt with --embed-mcp (which in turn spawns vtk-mcp itself).
+#
+# vtk-mcp is intentionally NOT pointed at this Qdrant instance: it starts
+# empty, and the on-disk format vtk-index's embedded (client-local-mode)
+# storage writes is not directly loadable by the full Qdrant server's
+# raft-tracked collection registry, so retrieval would silently return
+# nothing. vtk-mcp instead uses its own prefetched embedded storage
+# (baked into the image at build time), which is the supported, working
+# path. The Qdrant process here is for optional external use.
+set -e
+
+/qdrant/qdrant &
+QDRANT_PID=$!
+trap 'kill "$QDRANT_PID" 2>/dev/null' EXIT
+
+echo "Waiting for Qdrant to become ready..." >&2
+python - <<'PYEOF'
+import time
+import urllib.request
+
+for _ in range(60):
+    try:
+        urllib.request.urlopen("http://localhost:6333/readyz", timeout=1)
+        break
+    except Exception:
+        time.sleep(1)
+else:
+    raise SystemExit("Qdrant did not become ready in time")
+PYEOF
+
+exec vtk-prompt --embed-mcp "$@"

--- a/scripts/vtk-prompt-with-mcp-entrypoint.sh
+++ b/scripts/vtk-prompt-with-mcp-entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 # Starts the local Qdrant process (available on :6333 for anyone who wants to
 # index or inspect it), waits for it to accept connections, then runs
-# vtk-prompt with --embed-mcp (which in turn spawns vtk-mcp itself).
+# vtk-prompt with --embed-mcp (which in turn spawns vtk-mcp itself). Pass
+# "ui" as the first argument to launch vtk-prompt-ui (also embedded) instead,
+# e.g. `docker run -p 8080:8080 <image> ui`.
 #
 # vtk-mcp is intentionally NOT pointed at this Qdrant instance: it starts
 # empty, and the on-disk format vtk-index's embedded (client-local-mode)
@@ -30,5 +32,10 @@ for _ in range(60):
 else:
     raise SystemExit("Qdrant did not become ready in time")
 PYEOF
+
+if [ "$1" = "ui" ]; then
+    shift
+    exec vtk-prompt-ui --embed-mcp --host 0.0.0.0 --server "$@"
+fi
 
 exec vtk-prompt --embed-mcp "$@"

--- a/scripts/vtk-prompt-with-mcp.Dockerfile
+++ b/scripts/vtk-prompt-with-mcp.Dockerfile
@@ -1,0 +1,73 @@
+# vtk-prompt-with-mcp: a single self-contained image bundling a local Qdrant
+# server, vtk-mcp, and vtk-prompt (launched via its --embed-mcp flag). No
+# docker compose, no separate vtk-mcp container, no manual startup step.
+#
+# The build context must be a directory containing both sibling repos as
+# vtk-prompt/ and vtk-mcp/ (this is how CI checks them out; see
+# .github/workflows/ci.yml's docker-deploy job). For local development,
+# run from the parent directory of both checkouts:
+#
+#   docker build -f vtk-prompt/scripts/vtk-prompt-with-mcp.Dockerfile \
+#                --ignorefile vtk-prompt/scripts/vtk-prompt-with-mcp.dockerignore \
+#                -t vtk-prompt-with-mcp .
+#   docker run --rm -it vtk-prompt-with-mcp "Create a red sphere" -t $ANTHROPIC_API_KEY
+
+FROM qdrant/qdrant:latest AS qdrant
+
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.title="vtk-prompt-with-mcp"
+LABEL org.opencontainers.image.description="vtk-prompt with an embedded vtk-mcp server and local Qdrant"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# VTK version to pre-cache at image build time
+ARG VTK_VERSION=9.6.1
+ENV VTK_MCP_VTK_VERSION=${VTK_VERSION}
+
+# libunwind8 satisfies the Qdrant binary's runtime linker deps (it's built
+# against glibc/libunwind on a fuller Debian base than python:3.12-slim).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git libunwind8 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Bring in the Qdrant server binary + default config from the official image.
+COPY --from=qdrant /qdrant/qdrant /qdrant/qdrant
+COPY --from=qdrant /qdrant/config /qdrant/config
+
+WORKDIR /app
+
+RUN pip install uv
+
+# Install vtk-* sibling packages from GitHub (not on PyPI). vtk-validate's
+# "translate" extra (litellm) powers vtk-mcp's translate_prompt_to_dsl tool,
+# which vtk-prompt calls by default (--dsl-translation).
+RUN uv pip install --system \
+    "git+https://github.com/vicentebolea/vtk-knowledge" \
+    "vtk-validate[translate] @ git+https://github.com/vicentebolea/vtk-validate" \
+    "git+https://github.com/vicentebolea/vtk-index"
+
+COPY vtk-mcp/ /app/vtk-mcp/
+COPY vtk-prompt/ /app/vtk-prompt/
+
+RUN uv pip install --system -e "/app/vtk-mcp[retrieval]"
+RUN uv pip install --system -e "/app/vtk-prompt"
+
+# Pre-download the vtk-knowledge JSONL artifact and vtk-index embedded
+# Qdrant storage so the image needs no network access to start serving.
+RUN python /app/vtk-mcp/scripts/prefetch_artifacts.py
+
+ENV VTK_MCP_ENABLE_VALIDATION=true
+
+COPY vtk-prompt/scripts/vtk-prompt-with-mcp-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh /qdrant/qdrant
+
+# Qdrant is started for optional external indexing/inspection; see
+# docker-entrypoint.sh for why vtk-mcp doesn't use it for retrieval.
+EXPOSE 6333
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/scripts/vtk-prompt-with-mcp.Dockerfile
+++ b/scripts/vtk-prompt-with-mcp.Dockerfile
@@ -11,6 +11,9 @@
 #                --ignorefile vtk-prompt/scripts/vtk-prompt-with-mcp.dockerignore \
 #                -t vtk-prompt-with-mcp .
 #   docker run --rm -it vtk-prompt-with-mcp "Create a red sphere" -t $ANTHROPIC_API_KEY
+#
+#   # Or the web UI instead of the CLI:
+#   docker run --rm -it -p 8080:8080 vtk-prompt-with-mcp ui
 
 FROM qdrant/qdrant:latest AS qdrant
 
@@ -63,11 +66,20 @@ RUN python /app/vtk-mcp/scripts/prefetch_artifacts.py
 
 ENV VTK_MCP_ENABLE_VALIDATION=true
 
+# No display in this container. VTK's default GLX/X11 render window still
+# tries to open an X server even with OffScreenRenderingOn() (see
+# rendering/scene_manager.py), which segfaults here. Force the OSMesa
+# software-rasterizer backend that ships in the same "vtk" wheel instead, so
+# both vtk-prompt-ui and any rendering the generated code does work headless.
+ENV VTK_DEFAULT_OPENGL_WINDOW=vtkOSOpenGLRenderWindow
+
 COPY vtk-prompt/scripts/vtk-prompt-with-mcp-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh /qdrant/qdrant
 
 # Qdrant is started for optional external indexing/inspection; see
 # docker-entrypoint.sh for why vtk-mcp doesn't use it for retrieval.
 EXPOSE 6333
+# vtk-prompt-ui, when launched via `docker run <image> ui`.
+EXPOSE 8080
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/scripts/vtk-prompt-with-mcp.dockerignore
+++ b/scripts/vtk-prompt-with-mcp.dockerignore
@@ -1,0 +1,41 @@
+# Python
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/*.so
+**/build/
+**/dist/
+**/*.egg-info/
+
+# Virtual environments
+**/.venv/
+**/venv/
+**/env/
+**/ENV/
+
+# Testing
+**/.pytest_cache/
+**/.coverage
+**/htmlcov/
+**/.tox/
+**/.ruff_cache/
+
+# IDE
+**/.vscode/
+**/.idea/
+**/*.swp
+
+# Git
+**/.git/
+**/.gitignore
+
+# CI/CD
+**/.github/
+
+# Local development
+**/.env
+**/*.log
+**/tmp/
+
+# OS
+**/.DS_Store

--- a/src/vtk_prompt/cli.py
+++ b/src/vtk_prompt/cli.py
@@ -44,7 +44,7 @@ logger = get_logger(__name__)
 @click.option(
     "--embed-mcp",
     is_flag=True,
-    help="Launch a local vtk-mcp server automatically (requires vtk-prompt[embedded-mcp])",
+    help="Launch a local vtk-mcp server automatically (requires vtk-mcp to be installed)",
 )
 @click.option("--top-k", type=int, default=5, help="Number of examples to retrieve from vtk-mcp")
 @click.option(

--- a/src/vtk_prompt/cli.py
+++ b/src/vtk_prompt/cli.py
@@ -8,12 +8,14 @@ Example:
     >>> vtk-prompt "create sphere" --mcp-url http://localhost:8000 --model claude-sonnet-5
 """
 
+import contextlib
 import sys
 
 import click
 
 from . import get_logger
 from .client import VTKPromptClient, load_conversation, save_conversation
+from .mcp_launcher import embedded_mcp_server
 from .provider_utils import DEFAULT_MODEL, DEFAULT_PROVIDER, get_default_model, supports_temperature
 
 logger = get_logger(__name__)
@@ -39,6 +41,11 @@ logger = get_logger(__name__)
 @click.option("--base-url", help="Base URL for API (auto-detected or custom)")
 @click.option("-v", "--verbose", is_flag=True, help="Show generated source code")
 @click.option("--mcp-url", default=None, help="vtk-mcp server URL")
+@click.option(
+    "--embed-mcp",
+    is_flag=True,
+    help="Launch a local vtk-mcp server automatically (requires vtk-prompt[embedded-mcp])",
+)
 @click.option("--top-k", type=int, default=5, help="Number of examples to retrieve from vtk-mcp")
 @click.option(
     "--retry-attempts",
@@ -74,6 +81,7 @@ def main(
     base_url: str | None,
     verbose: bool,
     mcp_url: str | None,
+    embed_mcp: bool,
     top_k: int,
     retry_attempts: int,
     conversation: str | None,
@@ -86,6 +94,9 @@ def main(
 
     INPUT_STRING: The code description to generate VTK code for
     """
+    if embed_mcp and mcp_url:
+        raise click.UsageError("--embed-mcp and --mcp-url are mutually exclusive")
+
     # Set default base URLs
     if base_url is None:
         base_urls = {
@@ -149,51 +160,54 @@ def main(
         )
         temperature = 1.0
 
+    mcp_context = embedded_mcp_server() if embed_mcp else contextlib.nullcontext(mcp_url)
+
     try:
-        client = VTKPromptClient(verbose=verbose, mcp_url=mcp_url)
-        # The caller owns the conversation: load it, hand it to query, save it back.
-        messages = load_conversation(conversation)
-        result = client.query(
-            input_string,
-            conversation=messages,
-            api_key=token,
-            model=model,
-            base_url=base_url,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_k=top_k,
-            retry_attempts=retry_attempts,
-            provider=provider,
-            custom_prompt=custom_prompt_data,
-            dsl_translation=dsl_translation,
-            debug=debug,
-        )
-        save_conversation(conversation, messages)
+        with mcp_context as effective_mcp_url:
+            client = VTKPromptClient(verbose=verbose, mcp_url=effective_mcp_url)
+            # The caller owns the conversation: load it, hand it to query, save it back.
+            messages = load_conversation(conversation)
+            result = client.query(
+                input_string,
+                conversation=messages,
+                api_key=token,
+                model=model,
+                base_url=base_url,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_k=top_k,
+                retry_attempts=retry_attempts,
+                provider=provider,
+                custom_prompt=custom_prompt_data,
+                dsl_translation=dsl_translation,
+                debug=debug,
+            )
+            save_conversation(conversation, messages)
 
-        # Handle result with optional validation warnings
-        if isinstance(result, tuple):
-            if len(result) == 4:
-                # Result includes validation warnings
-                explanation, generated_code, usage, validation_warnings = result
-                # Display validation warnings
-                for warning in validation_warnings:
-                    logger.warning("Custom prompt validation: %s", warning)
-            elif len(result) == 3:
-                explanation, generated_code, usage = result
+            # Handle result with optional validation warnings
+            if isinstance(result, tuple):
+                if len(result) == 4:
+                    # Result includes validation warnings
+                    explanation, generated_code, usage, validation_warnings = result
+                    # Display validation warnings
+                    for warning in validation_warnings:
+                        logger.warning("Custom prompt validation: %s", warning)
+                elif len(result) == 3:
+                    explanation, generated_code, usage = result
+                else:
+                    logger.info("Result: %s", result)
+                    return
+
+                if verbose and usage:
+                    logger.info(
+                        "Used tokens: input=%d output=%d",
+                        usage.prompt_tokens,
+                        usage.completion_tokens,
+                    )
+                client.run_code(generated_code)
             else:
+                # Handle string result
                 logger.info("Result: %s", result)
-                return
-
-            if verbose and usage:
-                logger.info(
-                    "Used tokens: input=%d output=%d",
-                    usage.prompt_tokens,
-                    usage.completion_tokens,
-                )
-            client.run_code(generated_code)
-        else:
-            # Handle string result
-            logger.info("Result: %s", result)
 
     except ValueError as e:
         if "max_tokens" in str(e):
@@ -204,6 +218,9 @@ def main(
         else:
             logger.error("Error: %s", e)
             sys.exit(4)
+    except RuntimeError as e:
+        logger.error("Error: %s", e)
+        sys.exit(4)
 
 
 if __name__ == "__main__":

--- a/src/vtk_prompt/mcp_launcher.py
+++ b/src/vtk_prompt/mcp_launcher.py
@@ -1,0 +1,73 @@
+"""Launch a local vtk-mcp server as a subprocess for embedded use.
+
+Lets ``vtk-prompt --embed-mcp`` provide context-enhanced generation without a
+separately started vtk-mcp server (docker compose, manual
+``vtk-mcp --transport http``, etc.).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+
+from . import get_logger
+from .vtk_mcp_client import check_mcp_available
+
+logger = get_logger(__name__)
+
+DEFAULT_STARTUP_TIMEOUT = 180.0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@contextlib.contextmanager
+def embedded_mcp_server(startup_timeout: float = DEFAULT_STARTUP_TIMEOUT) -> Iterator[str]:
+    """Spawn a local vtk-mcp HTTP server for the duration of the ``with`` block.
+
+    Yields the server's base URL. Raises RuntimeError if vtk-mcp isn't
+    installed or doesn't become ready within ``startup_timeout`` seconds
+    (the first run can be slow: vtk-mcp downloads its knowledge/embedding
+    artifacts on first use).
+    """
+    if importlib.util.find_spec("vtk_mcp") is None:
+        raise RuntimeError(
+            "vtk-mcp is not installed. Install it with: pip install 'vtk-prompt[embedded-mcp]'"
+        )
+
+    port = _free_port()
+    url = f"http://127.0.0.1:{port}"
+    logger.info("Starting embedded vtk-mcp on %s", url)
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "vtk_mcp", "--transport", "http", "--port", str(port)]
+    )
+
+    try:
+        deadline = time.monotonic() + startup_timeout
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                raise RuntimeError(f"embedded vtk-mcp exited early with code {proc.returncode}")
+            if check_mcp_available(url):
+                logger.info("Embedded vtk-mcp ready at %s", url)
+                break
+            time.sleep(0.5)
+        else:
+            raise RuntimeError(f"embedded vtk-mcp did not become ready within {startup_timeout}s")
+
+        yield url
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)

--- a/src/vtk_prompt/mcp_launcher.py
+++ b/src/vtk_prompt/mcp_launcher.py
@@ -40,7 +40,8 @@ def embedded_mcp_server(startup_timeout: float = DEFAULT_STARTUP_TIMEOUT) -> Ite
     """
     if importlib.util.find_spec("vtk_mcp") is None:
         raise RuntimeError(
-            "vtk-mcp is not installed. Install it with: pip install 'vtk-prompt[embedded-mcp]'"
+            "vtk-mcp is not installed. Install it with: "
+            "pip install 'git+https://github.com/Kitware/vtk-mcp'"
         )
 
     port = _free_port()

--- a/src/vtk_prompt/vtk_prompt_ui.py
+++ b/src/vtk_prompt/vtk_prompt_ui.py
@@ -29,6 +29,7 @@ from vtkmodules.vtkInteractionStyle import vtkInteractorStyleSwitch  # noqa
 
 from . import get_logger
 from .controllers import configuration, conversation, generation, sessions
+from .mcp_launcher import embedded_mcp_server
 from .rendering import (
     add_default_scene,
     setup_vtk_renderer,
@@ -107,6 +108,16 @@ class VTKPromptApp(TrameApp):
             dest="prompt_file",
         )
 
+        # Registered so wslink's arg parser accepts it; main() reads it from
+        # sys.argv directly (same pattern as --debug) since it must be known
+        # before the embedded vtk-mcp server is started, ahead of app creation.
+        self.server.cli.add_argument(
+            "--embed-mcp",
+            action="store_true",
+            help="Launch a local vtk-mcp server automatically (requires vtk-mcp to be installed)",
+            dest="embed_mcp",
+        )
+
         # Make sure JS is loaded
         file_handlers.load_js(self.server)
 
@@ -125,9 +136,7 @@ class VTKPromptApp(TrameApp):
         # (same names the generated code's exec scope sees).
         from .completion import register_runtime_objects, warm_up
 
-        register_runtime_objects(
-            renderer=self.renderer, render_window=self.render_window
-        )
+        register_runtime_objects(renderer=self.renderer, render_window=self.render_window)
         # Prime jedi's vtk analysis in the background so the first editor
         # completion is fast and Monaco does not time out and close the popup.
         warm_up()
@@ -559,10 +568,21 @@ def main() -> None:
     # wslink already defines --debug (its own debug logging); reuse it here to
     # also dump the LLM conversation instead of registering a conflicting flag.
     debug = "--debug" in sys.argv
+    embed_mcp = "--embed-mcp" in sys.argv
 
     # Create and start the app
-    app = VTKPromptApp(custom_prompt_file=custom_prompt_file, debug=debug)
-    app.start()
+    if embed_mcp:
+        try:
+            with embedded_mcp_server() as mcp_url:
+                app = VTKPromptApp(custom_prompt_file=custom_prompt_file, debug=debug)
+                app.state.mcp_url = mcp_url
+                app.start()
+        except RuntimeError as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+    else:
+        app = VTKPromptApp(custom_prompt_file=custom_prompt_file, debug=debug)
+        app.start()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,3 +155,54 @@ class TestCLI:
             result = self.runner.invoke(main, ["create sphere", "--token", "test-token"])
 
             assert result.exit_code == 4
+
+    def test_embed_mcp_and_mcp_url_mutually_exclusive(self):
+        """--embed-mcp and --mcp-url cannot be used together."""
+        result = self.runner.invoke(
+            main,
+            [
+                "create sphere",
+                "--token",
+                "test-token",
+                "--embed-mcp",
+                "--mcp-url",
+                "http://localhost:8000",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.output
+
+    def test_embed_mcp_launches_embedded_server(self):
+        """--embed-mcp launches the embedded server and forwards its URL."""
+        with (
+            patch("vtk_prompt.cli.embedded_mcp_server") as mock_embed,
+            patch.object(VTKPromptClient, "__new__") as mock_new,
+        ):
+            mock_embed.return_value.__enter__ = Mock(return_value="http://127.0.0.1:12345")
+            mock_embed.return_value.__exit__ = Mock(return_value=False)
+
+            mock_client = Mock()
+            mock_new.return_value = mock_client
+            mock_client.query.return_value = ("explanation", "code", None)
+            mock_client.run_code.return_value = None
+
+            result = self.runner.invoke(
+                main, ["create sphere", "--token", "test-token", "--embed-mcp"]
+            )
+
+            assert result.exit_code == 0
+            mock_embed.assert_called_once()
+            assert mock_new.call_args[1]["mcp_url"] == "http://127.0.0.1:12345"
+
+    def test_embed_mcp_startup_failure(self):
+        """A RuntimeError from the embedded server surfaces as exit code 4."""
+        with patch("vtk_prompt.cli.embedded_mcp_server") as mock_embed:
+            mock_embed.return_value.__enter__ = Mock(
+                side_effect=RuntimeError("vtk-mcp is not installed")
+            )
+
+            result = self.runner.invoke(
+                main, ["create sphere", "--token", "test-token", "--embed-mcp"]
+            )
+
+            assert result.exit_code == 4

--- a/tests/test_mcp_launcher.py
+++ b/tests/test_mcp_launcher.py
@@ -1,0 +1,67 @@
+"""Tests for the embedded vtk-mcp subprocess launcher."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vtk_prompt.mcp_launcher import _free_port, embedded_mcp_server
+
+
+class TestFreePort:
+    def test_returns_bindable_port(self):
+        port = _free_port()
+        assert 0 < port < 65536
+
+
+class TestEmbeddedMcpServer:
+    def test_raises_when_vtk_mcp_not_installed(self):
+        with patch("vtk_prompt.mcp_launcher.importlib.util.find_spec", return_value=None):
+            with pytest.raises(RuntimeError, match="not installed"):
+                with embedded_mcp_server():
+                    pass
+
+    def test_yields_url_once_ready(self):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+
+        with (
+            patch("vtk_prompt.mcp_launcher.importlib.util.find_spec", return_value=object()),
+            patch("vtk_prompt.mcp_launcher.subprocess.Popen", return_value=mock_proc),
+            patch("vtk_prompt.mcp_launcher.check_mcp_available", return_value=True),
+            patch("vtk_prompt.mcp_launcher._free_port", return_value=12345),
+        ):
+            with embedded_mcp_server() as url:
+                assert url == "http://127.0.0.1:12345"
+
+        mock_proc.terminate.assert_called_once()
+
+    def test_raises_if_process_exits_early(self):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with (
+            patch("vtk_prompt.mcp_launcher.importlib.util.find_spec", return_value=object()),
+            patch("vtk_prompt.mcp_launcher.subprocess.Popen", return_value=mock_proc),
+            patch("vtk_prompt.mcp_launcher._free_port", return_value=12345),
+        ):
+            with pytest.raises(RuntimeError, match="exited early"):
+                with embedded_mcp_server():
+                    pass
+
+    def test_raises_on_startup_timeout(self):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+
+        with (
+            patch("vtk_prompt.mcp_launcher.importlib.util.find_spec", return_value=object()),
+            patch("vtk_prompt.mcp_launcher.subprocess.Popen", return_value=mock_proc),
+            patch("vtk_prompt.mcp_launcher.check_mcp_available", return_value=False),
+            patch("vtk_prompt.mcp_launcher._free_port", return_value=12345),
+            patch("vtk_prompt.mcp_launcher.time.sleep"),
+        ):
+            with pytest.raises(RuntimeError, match="did not become ready"):
+                with embedded_mcp_server(startup_timeout=0.01):
+                    pass
+
+        mock_proc.terminate.assert_called_once()


### PR DESCRIPTION
- **Add MCP tool-call support for local and text-emitting backends**
- **Support concurrent conversations, each owning its own state**
- **Add a console panel and data-file suggestions**
- **Key the editor on conversation only, to not break autocomplete**
- **Auto-translate natural language prompts to DSL via vtk-mcp**
- **Add --embed-mcp flag and CI build for vtk-prompt-with-mcp image**
